### PR TITLE
Fix default value parser

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -136,7 +136,7 @@ def parse_sql_column(line: str) -> str:
     if 'not null' not in opts:
         code += '->nullable()'
     # Default value (escaped)
-    dv = re.search(r"default\s+'([^']*)'", opts) or re.search(r"default\s+([^, ]+)", opts)
+    dv = re.search(r"default\s+'([^']*)'", rest, re.I) or re.search(r"default\s+([^, ]+)", rest, re.I)
     if dv and dv.group(1).lower() != 'null':
         val = dv.group(1).replace("'", "\\'")
         code += f"->default('{val}')"


### PR DESCRIPTION
## Summary
- preserve case when parsing DEFAULT values in `parse_sql_column`

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb2684b90832095d4f00f1f3575f3